### PR TITLE
Fix missing root layout for page

### DIFF
--- a/src/app/items/layout.tsx
+++ b/src/app/items/layout.tsx
@@ -1,0 +1,21 @@
+import { routing } from "@/i18n/routing";
+import { NextIntlClientProvider, hasLocale } from "next-intl";
+import { notFound } from "next/navigation";
+import { SearchContextProvider } from "@/(contexts)/searchContext/page";
+import "../globals.css";
+
+export default async function ItemsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="es">
+      <body>
+        <NextIntlClientProvider>
+          <SearchContextProvider>{children}</SearchContextProvider>
+        </NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
Add `src/app/items/layout.tsx` to provide a root layout for the `/items` route, resolving the "doesn't have a root layout" build error.

The `items/page.tsx` was not located within the `[locale]` route group, preventing it from inheriting the global root layout defined in `src/app/[locale]/layout.tsx`. Next.js App Router requires every page to have a root layout, so this new layout file ensures the `/items` route meets this requirement.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ad5a492-c03d-4bc8-ba22-f5a9f1e1b7e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ad5a492-c03d-4bc8-ba22-f5a9f1e1b7e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

